### PR TITLE
Disable verbose output for upload

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ Hdfs.prototype.upload = function (param, callback) {
         if (e) {
             callback(e, r, b);
         } else {
-            console.log(r);
+            // console.log(r);
             if (r.statusCode == 201) {
                if(pb.spnego_token != undefined){
                    krb5.kinit({


### PR DESCRIPTION
Disable verbose output for upload.
The `console.log(r)` creates massive amounts of logs, extremely verbose and basically floods the console making all other logs useless. So it's better to comment it out.